### PR TITLE
Do not require QEMU extra options

### DIFF
--- a/run_glibc_testsuite.py
+++ b/run_glibc_testsuite.py
@@ -190,7 +190,7 @@ def main():
                                    args.unfs,
                                    args.cpu,
                                    args.qemu_path,
-                                   args.qemu_extra_opts.split(' '),
+                                   args.qemu_extra_opts,
                                    args.nsim_path,
                                    args.nsim_propsfile,
                                    args.nsim_ifname,

--- a/testsuite/glibctestsuite.py
+++ b/testsuite/glibctestsuite.py
@@ -144,7 +144,7 @@ class GlibcTestSuite:
         ]
 
         if self.qemu_extra_opts:
-            qemu_options += self.qemu_extra_opts
+            qemu_options += self.qemu_extra_opts.split (' ')
 
         qemu_log = os.path.join(self.build_dir, f'qemu-{utils.timestamp()}.log')
 


### PR DESCRIPTION
Without this fix ./run_glibc_testsuite.py without
--qemu-extra-opts will fail with:
Traceback (most recent call last):
  File "./run_glibc_testsuite.py", line 225, in <module>
    sys.exit(main())
  File "./run_glibc_testsuite.py", line 193, in main
    args.qemu_extra_opts.split(' '),
AttributeError: 'NoneType' object has no attribute 'split'

Signed-off-by: Vladimir Isaev <isaev@synopsys.com>